### PR TITLE
Started Docker install script blueprint

### DIFF
--- a/installDocker.sh
+++ b/installDocker.sh
@@ -1,0 +1,17 @@
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+curl -L -o docker-desktop.deb "https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb"
+
+sudo apt-get update
+
+sudo apt-get install ./docker-desktop.deb

--- a/installDocker.sh
+++ b/installDocker.sh
@@ -1,17 +1,19 @@
+# Add Docker's official GPG key:
 sudo apt-get update
 sudo apt-get install ca-certificates curl
 sudo install -m 0755 -d /etc/apt/keyrings
 sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
 sudo chmod a+r /etc/apt/keyrings/docker.asc
 
+# Add the repository to Apt sources:
 echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
 
-curl -L -o docker-desktop.deb "https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb"
+# Install the Docker packages:
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-sudo apt-get update
-
-sudo apt-get install ./docker-desktop.deb
+# Verify that the installation is successful by running the hello-world image:
+sudo docker run hello-world


### PR DESCRIPTION
Created Docker install script blueprint.
The script results in an error, but the Docker docs instruct to ignore this.

![Screenshot from 2024-12-02 09-40-47](https://github.com/user-attachments/assets/86a544c1-5d7c-4aab-a5df-4535d7b1b3f6)


![Screenshot from 2024-12-02 09-40-18](https://github.com/user-attachments/assets/770b29df-1330-4890-89ce-e685a39c5ddb)